### PR TITLE
[added] Edit saved lists

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -204,3 +204,10 @@
   border-top-color: var(--secondary);
   will-change: transform;
 }
+
+[data-sonner-toaster][data-sonner-theme=dark] [data-description] {
+  color: var(--foreground) !important;
+}
+[data-sonner-toaster][data-sonner-theme=light] [data-description] {
+  color: var(--foreground) !important;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -176,7 +176,7 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 650px) {
   .col-button {
     flex-direction: column;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -183,8 +183,8 @@
 }
 
 @media (hover: none) and (pointer: coarse) {
-  .trash-mobile {
-    opacity: 100%;
+  .trash-mobile, .x-mobile {
+    opacity: 1 !important;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import MenuIcons from "@/components/ui/menu-icons"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ExternalLink } from 'lucide-react';
 import VersionText from "@/components/version-text"
+import { Toaster } from "@/components/ui/sonner"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -110,6 +111,7 @@ export default function RootLayout({
           </HoverCard>
         </footer>
         </ThemeProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -112,6 +112,7 @@ export default function RootLayout({
         </footer>
         </ThemeProvider>
         <Toaster 
+          position="top-right"
           toastOptions={{
             className: "backdrop-blur",
           }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -111,7 +111,11 @@ export default function RootLayout({
           </HoverCard>
         </footer>
         </ThemeProvider>
-        <Toaster />
+        <Toaster 
+          toastOptions={{
+            className: "backdrop-blur",
+          }}
+        />
       </body>
     </html>
   );

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Check, CircleX, X, Trash2, Download } from "lucide-react"
 import LoadingCircleSpinner from "@/components/ui/loadingCircle"
 import { toast } from "sonner"
+import EditSheet from "@/components/ui/edit-sheet";
 
 
 function ResultsContent() {
@@ -167,7 +168,7 @@ function ResultsContent() {
                     <Button
                       variant="outline"
                       size="sm"
-                      aria-label="Action"
+                      aria-label="Save"
                       onClick={() => saveChecklistToLocalStorage(checklist)}
                     >
                       Save
@@ -184,16 +185,9 @@ function ResultsContent() {
                     )}
                     {checklist.slice(2).map((item, idx) => (
                     <li key={idx}>
-                      <div className="flex flex-row items-center gap-2 pb-3 group">
+                      <div className="flex flex-row items-center gap-2 pb-3">
                         <Checkbox />
                         {item}
-                        <button
-                          className="opacity-0 group-hover:opacity-100 transition-opacity"
-                          aria-label="Delete"
-                          onClick={() => deleteCheck(idx)}
-                        >
-                          <X size={20} className="text-destructive hover:text-destructive/50 cursor-pointer"/>
-                        </button>
                       </div>
                     </li>
                     ))}
@@ -220,9 +214,9 @@ function ResultsContent() {
                     disabled
                     className="opacity-50 pointer-events-none"
                   >
-                    Saved
                     <Check></Check>
                   </Button>
+                  <EditSheet checklistID={loadedSavedChecklist.id}></EditSheet>
                 </div>
                 <ul>
                   {loadedSavedChecklist.category !== 1 && (
@@ -235,16 +229,9 @@ function ResultsContent() {
                   )}
                   {loadedSavedChecklist.items.map((item: string, idx: number) => (
                   <li key={idx}>
-                    <div className="flex flex-row items-center gap-2 pb-3 group">
+                    <div className="flex flex-row items-center gap-2 pb-3">
                       <Checkbox />
                       {item}
-                      <button
-                        className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        aria-label="Delete"
-                        onClick={() => deleteCheck(idx)}
-                      >
-                        <X size={20} className="text-destructive hover:text-destructive/50 cursor-pointer"/>
-                      </button>
                     </div>
                   </li>
                   ))}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card"
 import { useSearchParams } from "next/navigation"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Check, CircleX, X, Trash2, Download } from "lucide-react"
+import { Check, CircleX, Download, FileCheck } from "lucide-react"
 import LoadingCircleSpinner from "@/components/ui/loadingCircle"
 import { toast } from "sonner"
 import EditSheet from "@/components/ui/edit-sheet";
@@ -73,34 +73,6 @@ function ResultsContent() {
     }
   }, [checklist, loadedSavedChecklist]);
 
-  function deleteCheck(idx: number) {
-    if (checklist && checklist.length > 0) {
-      toast("Item Removed", {
-        description: checklist[idx + 2],
-        icon: <Trash2 className="text-destructive" />,
-      });
-      setChecklist((prev) => prev.filter((_, i) => i !== idx + 2));
-    } else if (loadedSavedChecklist && loadedSavedChecklist.items.length > 0) {
-      toast("Item Removed", {
-        description: loadedSavedChecklist.items[idx],
-        icon: <Trash2 className="text-destructive" />,
-      });
-      const updatedChecklist = {
-        ...loadedSavedChecklist,
-        items: loadedSavedChecklist.items.filter((_: string, i: number) => i !== idx),
-      };
-      // Update localStorage
-      const saved = JSON.parse(localStorage.getItem("savedChecklists") || "[]");
-      const updatedSaved = saved.map((item: any) =>
-        item.id === loadedSavedChecklist.id ? updatedChecklist : item
-      );
-      localStorage.setItem("savedChecklists", JSON.stringify(updatedSaved));
-      // Reload the checklist from localStorage to ensure state is in sync
-      const reloaded = updatedSaved.find((item: any) => item.id === loadedSavedChecklist.id);
-      setLoadedSavedChecklist(reloaded);
-    }
-  }
-
   // Type for a saved checklist
   interface SavedChecklist {
     id: string;
@@ -127,6 +99,21 @@ function ResultsContent() {
       icon: <Download className="text-primary" />,
     });
     setChecklist([]);
+  }
+
+  function updateSavedChecklist() {
+    const updatedSaved = JSON.parse(localStorage.getItem("savedChecklists") || "[]");
+    const reloaded = updatedSaved.find((item: any) => item.id === loadedSavedChecklist.id);
+    if (
+      reloaded &&
+      JSON.stringify(reloaded) !== JSON.stringify(loadedSavedChecklist)
+    ) {
+      setLoadedSavedChecklist(reloaded);
+      toast("Checklist Updated", {
+        description: loadedSavedChecklist.title,
+        icon: <FileCheck className="text-primary" />,
+      });
+    }
   }
 
   return (
@@ -172,6 +159,7 @@ function ResultsContent() {
                       onClick={() => saveChecklistToLocalStorage(checklist)}
                     >
                       Save
+                      <Download size={16} />
                     </Button>
                   </div>
                   <ul>
@@ -214,9 +202,13 @@ function ResultsContent() {
                     disabled
                     className="opacity-50 pointer-events-none"
                   >
-                    <Check></Check>
+                    <Check size={16}></Check>
                   </Button>
-                  <EditSheet checklistID={loadedSavedChecklist.id}></EditSheet>
+                  <EditSheet 
+                    checklistID={loadedSavedChecklist.id}
+                    onClose={() => updateSavedChecklist()}
+                  >
+                  </EditSheet>
                 </div>
                 <ul>
                   {loadedSavedChecklist.category !== 1 && (

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -195,20 +195,22 @@ function ResultsContent() {
                   <h1 className="text-2xl font-bold text-center flex-1">
                     {loadedSavedChecklist.title}
                   </h1>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    aria-label="Saved"
-                    disabled
-                    className="opacity-50 pointer-events-none"
-                  >
-                    <Check size={16}></Check>
-                  </Button>
-                  <EditSheet 
-                    checklistID={loadedSavedChecklist.id}
-                    onClose={() => updateSavedChecklist()}
-                  >
-                  </EditSheet>
+                  <div className="flex items-center justify-center gap-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      aria-label="Saved"
+                      disabled
+                      className="opacity-50 pointer-events-none"
+                    >
+                      <Check size={16}></Check>
+                    </Button>
+                    <EditSheet 
+                      checklistID={loadedSavedChecklist.id}
+                      onClose={() => updateSavedChecklist()}
+                    >
+                    </EditSheet>
+                  </div>
                 </div>
                 <ul>
                   {loadedSavedChecklist.category !== 1 && (

--- a/components/ui/ChecklistCard.tsx
+++ b/components/ui/ChecklistCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Briefcase, ShoppingCart, ListChecks, ClipboardList, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 interface ChecklistCardProps {
   id: string;
@@ -23,6 +24,10 @@ export function ChecklistCard({ id, title, category, date, onClick, onDelete }: 
   const router = useRouter();
 
   function handleDelete(e: React.MouseEvent) {
+    toast("Checklist Deleted", {
+      description: title,
+      icon: <Trash2 className="text-destructive" />,
+    });
     e.stopPropagation();
     // Remove from localStorage
     const existing = JSON.parse(localStorage.getItem("savedChecklists") || "[]");

--- a/components/ui/edit-sheet.tsx
+++ b/components/ui/edit-sheet.tsx
@@ -1,0 +1,92 @@
+"use client"
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { useEffect, useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox"
+import LoadingCircleSpinner from "@/components/ui/loadingCircle"
+import { CircleX } from "lucide-react"
+
+
+interface EditSheetProps {
+    checklistID: number;
+}
+
+export default function EditSheet({ checklistID }: EditSheetProps) {
+    const [saved, setSaved] = useState([]);
+    const [loading, setLoading] = useState(true);
+    
+    useEffect(() => {
+        setLoading(true);
+        const data = JSON.parse(localStorage.getItem("savedChecklists") || "[]");
+        setSaved(data);
+        setLoading(false);
+    }, []);
+
+    const loadedSavedChecklist = saved.find((item: any) => item.id === checklistID) || {};
+
+    return (
+        <Sheet>
+            <SheetTrigger asChild>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    aria-label="Edit"
+                >
+                    Edit
+                </Button>
+            </SheetTrigger>
+            <SheetContent>
+                <SheetHeader>
+                    <SheetTitle>Edit checklist</SheetTitle>
+                    <SheetDescription>
+                        Remove and add items to your generated checklist below.
+                    </SheetDescription>
+                </SheetHeader>
+                {loading ? (
+                    <LoadingCircleSpinner></LoadingCircleSpinner>
+                ) : (
+                    <div className="flex flex-col flex-1 overflow-y-auto max-h-[80vh]">
+                        <div className="p-4 flex-1">
+                            <ul>
+                                {loadedSavedChecklist.category !== 1 && (
+                                    <li>
+                                        <div className="flex flex-row items-center gap-2 pb-3">
+                                            <Checkbox checked />
+                                            <p>Generate a checklist with GenList AI</p>
+                                        </div>
+                                    </li>
+                                )}
+                                {(loadedSavedChecklist.items || []).map((item: string, idx: number) => (
+                                    <li key={idx}>
+                                        <div className="flex flex-row items-center gap-2 pb-3">
+                                            <CircleX 
+                                                size={20} 
+                                                className="text-destructive cursor-pointer hover:text-destructive/50"
+                                                onClick={() => deleteCheck(idx)}
+                                            />
+                                            {item}
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <SheetFooter>
+                          <SheetClose asChild>
+                            <Button>Done</Button>
+                          </SheetClose>
+                        </SheetFooter>
+                    </div>
+                )}
+            </SheetContent>
+        </Sheet>
+    )
+}

--- a/components/ui/edit-sheet.tsx
+++ b/components/ui/edit-sheet.tsx
@@ -11,18 +11,26 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { useEffect, useState } from "react";
-import { Checkbox } from "@/components/ui/checkbox"
 import LoadingCircleSpinner from "@/components/ui/loadingCircle"
-import { CircleX } from "lucide-react"
-
+import { Trash2, Pencil } from "lucide-react"
 
 interface EditSheetProps {
     checklistID: number;
+    onClose?: () => void;
 }
 
-export default function EditSheet({ checklistID }: EditSheetProps) {
+export default function EditSheet({ checklistID, onClose }: EditSheetProps) {
     const [saved, setSaved] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [loadedSavedChecklist, setLoadedSavedChecklist] = useState<any | null>(null);
+    const [open, setOpen] = useState(false);
+
+    function handleOpenChange(isOpen: boolean) {
+        setOpen(isOpen);
+        if (!isOpen && onClose) {
+            onClose();
+        }
+    }
     
     useEffect(() => {
         setLoading(true);
@@ -31,10 +39,30 @@ export default function EditSheet({ checklistID }: EditSheetProps) {
         setLoading(false);
     }, []);
 
-    const loadedSavedChecklist = saved.find((item: any) => item.id === checklistID) || {};
+    useEffect(() => {
+        setLoadedSavedChecklist(saved.find((item: any) => item.id === checklistID) || {});
+    }, [saved, checklistID]);
+
+  function deleteCheck(idx: number) {
+     if (loadedSavedChecklist && loadedSavedChecklist.items.length > 0) {
+      const updatedChecklist = {
+        ...loadedSavedChecklist,
+        items: loadedSavedChecklist.items.filter((_: string, i: number) => i !== idx),
+      };
+      // Update localStorage
+      const saved = JSON.parse(localStorage.getItem("savedChecklists") || "[]");
+      const updatedSaved = saved.map((item: any) =>
+        item.id === loadedSavedChecklist.id ? updatedChecklist : item
+      );
+      localStorage.setItem("savedChecklists", JSON.stringify(updatedSaved));
+      // Reload the checklist from localStorage to ensure state is in sync
+      const reloaded = updatedSaved.find((item: any) => item.id === loadedSavedChecklist.id);
+      setLoadedSavedChecklist(reloaded);
+    }
+  }
 
     return (
-        <Sheet>
+        <Sheet open={open} onOpenChange={handleOpenChange}>
             <SheetTrigger asChild>
                 <Button
                     variant="outline"
@@ -42,6 +70,7 @@ export default function EditSheet({ checklistID }: EditSheetProps) {
                     aria-label="Edit"
                 >
                     Edit
+                    <Pencil size={16} />
                 </Button>
             </SheetTrigger>
             <SheetContent>
@@ -54,37 +83,34 @@ export default function EditSheet({ checklistID }: EditSheetProps) {
                 {loading ? (
                     <LoadingCircleSpinner></LoadingCircleSpinner>
                 ) : (
-                    <div className="flex flex-col flex-1 overflow-y-auto max-h-[80vh]">
+                    <>
+                    <div className="flex flex-col flex-1 overflow-y-auto">
                         <div className="p-4 flex-1">
                             <ul>
-                                {loadedSavedChecklist.category !== 1 && (
-                                    <li>
-                                        <div className="flex flex-row items-center gap-2 pb-3">
-                                            <Checkbox checked />
-                                            <p>Generate a checklist with GenList AI</p>
-                                        </div>
-                                    </li>
-                                )}
                                 {(loadedSavedChecklist.items || []).map((item: string, idx: number) => (
                                     <li key={idx}>
-                                        <div className="flex flex-row items-center gap-2 pb-3">
-                                            <CircleX 
+                                        <div className="flex flex-row items-center gap-2 pb-2">
+                                            <Trash2 
                                                 size={20} 
-                                                className="text-destructive cursor-pointer hover:text-destructive/50"
+                                                className="text-destructive/75 cursor-pointer hover:text-destructive/50"
                                                 onClick={() => deleteCheck(idx)}
                                             />
                                             {item}
                                         </div>
+                                        {idx < (loadedSavedChecklist.items?.length || 0) - 1 && (
+                                            <hr className="border-t border-border w-full mb-2" />
+                                        )}
                                     </li>
                                 ))}
                             </ul>
                         </div>
+                    </div>
                         <SheetFooter>
                           <SheetClose asChild>
                             <Button>Done</Button>
                           </SheetClose>
                         </SheetFooter>
-                    </div>
+                    </>
                 )}
             </SheetContent>
         </Sheet>

--- a/components/ui/edit-sheet.tsx
+++ b/components/ui/edit-sheet.tsx
@@ -73,8 +73,8 @@ export default function EditSheet({ checklistID, onClose }: EditSheetProps) {
                     <Pencil size={16} />
                 </Button>
             </SheetTrigger>
-            <SheetContent>
-                <SheetHeader>
+            <SheetContent className="w-full max-w-full sm:max-w-sm pr-4 pl-4 sm:pr-1 sm:pl-1">
+                <SheetHeader className="pb-0">
                     <SheetTitle>Edit checklist</SheetTitle>
                     <SheetDescription>
                         Remove and add items to your generated checklist below.
@@ -83,35 +83,33 @@ export default function EditSheet({ checklistID, onClose }: EditSheetProps) {
                 {loading ? (
                     <LoadingCircleSpinner></LoadingCircleSpinner>
                 ) : (
-                    <>
-                    <div className="flex flex-col flex-1 overflow-y-auto">
-                        <div className="p-4 flex-1">
-                            <ul>
-                                {(loadedSavedChecklist.items || []).map((item: string, idx: number) => (
-                                    <li key={idx}>
-                                        <div className="flex flex-row items-center gap-2 pb-2">
-                                            <Trash2 
-                                                size={20} 
-                                                className="text-destructive/75 cursor-pointer hover:text-destructive/50"
-                                                onClick={() => deleteCheck(idx)}
-                                            />
-                                            {item}
-                                        </div>
-                                        {idx < (loadedSavedChecklist.items?.length || 0) - 1 && (
-                                            <hr className="border-t border-border w-full mb-2" />
-                                        )}
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    </div>
-                        <SheetFooter>
-                          <SheetClose asChild>
-                            <Button>Done</Button>
-                          </SheetClose>
-                        </SheetFooter>
-                    </>
+                <div className="flex p-4 overflow-y-auto">
+                    <ul>
+                        {(loadedSavedChecklist.items || []).map((item: string, idx: number) => (
+                        <li key={idx}>
+                            <div className="flex flex-row items-center gap-2 pb-2">
+                                <span className="w-5 flex-shrink-0 flex justify-center">
+                                    <Trash2 
+                                        size={20} 
+                                        className="text-destructive/75 cursor-pointer hover:text-destructive/50"
+                                        onClick={() => deleteCheck(idx)}
+                                    />
+                                </span>
+                                <span>{item}</span>
+                            </div>
+                            {idx < (loadedSavedChecklist.items?.length || 0) - 1 && (
+                                <hr className="border-t border-border w-full mb-2" />
+                            )}
+                        </li>
+                        ))}
+                    </ul>
+                </div>
                 )}
+                <SheetFooter className="pt-0">
+                    <SheetClose asChild>
+                        <Button>Done</Button>
+                    </SheetClose>
+                </SheetFooter>
             </SheetContent>
         </Sheet>
     )

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--input)",
+          "--normal-text": "var(--foreground)",
+          "--normal-border": "var(--input)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.4.0",
         "@radix-ui/react-checkbox": "^1.3.2",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-hover-card": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -840,6 +841,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
@@ -2791,6 +2792,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
+      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@google/genai": "^1.4.0",
     "@radix-ui/react-checkbox": "^1.3.2",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-hover-card": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",


### PR DESCRIPTION
This pull request introduces several enhancements to the user interface and functionality of the application, including the addition of toast notifications, an editable checklist feature, and improvements to responsiveness and styling. Below is a summary of the most important changes grouped by theme:

### Toast Notifications:
* Added the `Toaster` component to display toast notifications across the application. Integrated it into the layout (`app/layout.tsx`) and configured options such as position and styling. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR15) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR114-R119) [[3]](diffhunk://#diff-f101c4e63a934c276dcda6b25e86cc0d372f4fb2a61fd0ef4eb84895551a0928R1-R25)
* Implemented toast notifications for saving, updating, and deleting checklists in `ResultsContent` and `ChecklistCard`. Notifications include descriptions and icons for better user feedback. [[1]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0R97-R116) [[2]](diffhunk://#diff-c9597dc4c05abbaa531e496e1a16346b8904ebd2c7c4b798658bbe5b43890dc0R27-R30)

### Editable Checklists:
* Introduced the `EditSheet` component, allowing users to edit saved checklists by adding or removing items. It includes localStorage synchronization and a responsive design.
* Integrated the `EditSheet` component into the `ResultsContent` interface for editing loaded checklists.

### Styling and Responsiveness:
* Updated media queries in `app/globals.css` for improved responsiveness, including adjustments to mobile-specific styles and hover effects.
* Added custom styles for toast notifications based on light and dark themes in `app/globals.css`.

### New Dependencies:
* Added `@radix-ui/react-dialog` for the `EditSheet` component and `sonner` for toast notifications to `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R14) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27)